### PR TITLE
Release v5.0.0 + Nuxt module v1.0.0

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,11 +1,14 @@
 name: Deploy Documentation
 
 on:
-  push:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
     branches: [master]
 
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,14 @@
 name: Auto Release
 
 on:
-  push:
+  workflow_run:
+    workflows: ['Deploy Documentation']
+    types: [completed]
     branches: [master]
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -66,6 +66,7 @@ const circleStyle = ref({
 Create a simple interactive map with style switching and configuration options.
 
 **Topics Covered**:
+
 - Map initialization with options
 - Style switching (OSM, satellite, etc.)
 - Reactive property updates
@@ -73,6 +74,7 @@ Create a simple interactive map with style switching and configuration options.
 - Camera controls and state
 
 **Key Composables**:
+
 - `useCreateMaplibre()` - Map creation
 - `useMaplibre()` - Map context access
 - `useFlyTo()` - Smooth camera animation
@@ -82,6 +84,7 @@ Create a simple interactive map with style switching and configuration options.
 Add interactive markers to your map with advanced features.
 
 **Topics Covered**:
+
 - Marker creation and positioning
 - Draggable markers with event handling
 - Marker popups with custom content
@@ -90,11 +93,13 @@ Add interactive markers to your map with advanced features.
 - Marker removal and updates
 
 **Key Composables**:
+
 - `useCreateMarker()` - Programmatic marker creation
 - `useCreatePopup()` - Marker popups
 - `useMapEventListener()` - Interaction events
 
 **Key Components**:
+
 - `<Marker />` - Marker component
 - `<PopUp />` - Popup overlays
 
@@ -103,6 +108,7 @@ Add interactive markers to your map with advanced features.
 Work with all layer types: Fill, Circle, Line, and Symbol layers.
 
 **Topics Covered**:
+
 - Fill layers for polygons with styling
 - Circle layers for points with size/color
 - Line layers for routes/boundaries
@@ -113,12 +119,14 @@ Work with all layer types: Fill, Circle, Line, and Symbol layers.
 - Layer z-order management
 
 **Key Composables** (all with full type safety):
+
 - `useCreateFillLayer()` - Fill layers
 - `useCreateCircleLayer()` - Circle layers
 - `useCreateLineLayer()` - Line layers
 - `useCreateSymbolLayer()` - Symbol layers
 
 **Key Components**:
+
 - `<FillLayer />` - Fill layer component
 - `<CircleLayer />` - Circle layer component
 - `<LineLayer />` - Line layer component
@@ -129,6 +137,7 @@ Work with all layer types: Fill, Circle, Line, and Symbol layers.
 Integrate navigation controls and geolocation features.
 
 **Topics Covered**:
+
 - Geolocation control initialization
 - User location tracking
 - Geolocation events and permissions
@@ -137,23 +146,25 @@ Integrate navigation controls and geolocation features.
 - Error handling for location services
 
 **Key Composables**:
+
 - `useGeolocateControl()` - Programmatic geolocation
 - `useGeolocateEventListener()` - Geolocate events
 
 **Key Components**:
+
 - `<GeolocateControls />` - Geolocation control
 
 ## Example Structure
 
 Each example includes:
 
-| Section | Content |
-|---------|----------|
-| **Live Demo** | Interactive map with full functionality |
-| **Code** | Complete Vue component with explanations |
-| **Features** | Key capabilities highlighted |
-| **APIs** | Links to relevant composables/components |
-| **Variations** | Alternative approaches and patterns |
+| Section        | Content                                  |
+| -------------- | ---------------------------------------- |
+| **Live Demo**  | Interactive map with full functionality  |
+| **Code**       | Complete Vue component with explanations |
+| **Features**   | Key capabilities highlighted             |
+| **APIs**       | Links to relevant composables/components |
+| **Variations** | Alternative approaches and patterns      |
 
 ## Common Patterns
 
@@ -163,10 +174,13 @@ Each example includes:
 const geoData = ref({ type: 'FeatureCollection', features: [] });
 
 // Update data reactively
-watch(() => selectedRegion.value, (region) => {
-  const filtered = allFeatures.filter(f => f.properties.region === region);
-  geoData.value = { type: 'FeatureCollection', features: filtered };
-});
+watch(
+  () => selectedRegion.value,
+  (region) => {
+    const filtered = allFeatures.filter((f) => f.properties.region === region);
+    geoData.value = { type: 'FeatureCollection', features: filtered };
+  },
+);
 ```
 
 ### Camera Animations
@@ -189,7 +203,9 @@ const animateToLocation = async (location) => {
 const { isListenerAttached } = useMapEventListener('click', (e) => {
   console.log('Clicked at:', e.lngLat);
   // Get features at click point
-  const features = mapInstance.value?.queryRenderedFeatures({ layers: ['my-layer'] });
+  const features = mapInstance.value?.queryRenderedFeatures({
+    layers: ['my-layer'],
+  });
 });
 ```
 
@@ -199,13 +215,19 @@ const { isListenerAttached } = useMapEventListener('click', (e) => {
 const { setPaint, setFilter } = useCreateCircleLayer(mapInstance, sourceId);
 
 // Type-safe property updates
-watch(() => settings.radius, (newRadius) => {
-  setPaint({ 'circle-radius': newRadius, 'circle-color': '#088' });
-});
+watch(
+  () => settings.radius,
+  (newRadius) => {
+    setPaint({ 'circle-radius': newRadius, 'circle-color': '#088' });
+  },
+);
 
-watch(() => filters.name, (name) => {
-  setFilter(['in', 'name', ...name.split(',')]);
-});
+watch(
+  () => filters.name,
+  (name) => {
+    setFilter(['in', 'name', ...name.split(',')]);
+  },
+);
 ```
 
 ## Running Examples Locally
@@ -230,6 +252,7 @@ You can copy any example code and paste it into your Vue 3 project. All examples
 ## Best Practices
 
 1. **Always handle map readiness** before operations
+
    ```typescript
    watch(isMapReady, () => {
      // Map is interactive now
@@ -237,18 +260,21 @@ You can copy any example code and paste it into your Vue 3 project. All examples
    ```
 
 2. **Use type-safe layer composables** for compile-time validation
+
    ```typescript
    const { setPaint } = useCreateFillLayer(map, source);
    // setPaint only accepts FillPaint types
    ```
 
 3. **Await camera animations** for sequential operations
+
    ```typescript
    await flyTo({ center: [0, 0], zoom: 10 });
    // Camera animation complete
    ```
 
 4. **Clean up listeners** (automatic with composables)
+
    ```typescript
    const { removeListener } = useMapEventListener('click', handler);
    // Removed on component unmount automatically

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -243,7 +243,7 @@ bun install
 bun dev
 ```
 
-Then open http://localhost:5173 in your browser.
+Then open the local URL shown in your terminal (usually localhost on port 5173).
 
 ### Copy & Paste
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,53 +1,317 @@
 # Examples
 
-Explore practical examples of Vue MapLibre GL components and composables in action.
+Explore practical, production-ready examples of vue3-maplibre-gl v5 components and composables in action.
 
-## Getting Started
+## Quick Start
 
-All examples use the same basic setup. Make sure you have Vue MapLibre GL installed:
+### Installation
 
 ```bash
+bun add vue3-maplibre-gl
+# or
 npm install vue3-maplibre-gl
 ```
 
-And import the CSS in your main application file:
+### Import CSS
 
-```javascript
+```typescript
+// main.ts or in your component
 import 'vue3-maplibre-gl/dist/style.css';
+```
+
+### Basic Usage
+
+```vue
+<template>
+  <Maplibre :options="mapOptions" style="height: 500px">
+    <GeoJsonSource :data="geoData">
+      <CircleLayer :style="circleStyle" />
+    </GeoJsonSource>
+  </Maplibre>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { Maplibre, GeoJsonSource, CircleLayer } from 'vue3-maplibre-gl';
+import 'vue3-maplibre-gl/dist/style.css';
+
+const mapOptions = ref({
+  style: 'https://demotiles.maplibre.org/style.json',
+  center: [0, 0],
+  zoom: 2,
+});
+
+const geoData = ref({
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [0, 0] },
+      properties: { name: 'Center' },
+    },
+  ],
+});
+
+const circleStyle = ref({
+  'circle-radius': 6,
+  'circle-color': '#007cbf',
+});
+</script>
 ```
 
 ## Available Examples
 
 ### 🗺️ [Basic Map](/examples/basic-map)
 
-Learn how to create a simple map with different styles and basic configuration options.
+Create a simple interactive map with style switching and configuration options.
+
+**Topics Covered**:
+- Map initialization with options
+- Style switching (OSM, satellite, etc.)
+- Reactive property updates
+- Event handling (load, click, zoom)
+- Camera controls and state
+
+**Key Composables**:
+- `useCreateMaplibre()` - Map creation
+- `useMaplibre()` - Map context access
+- `useFlyTo()` - Smooth camera animation
 
 ### 📍 [Markers](/examples/markers)
 
-Add interactive markers to your map with custom styling, drag functionality, and event handling.
+Add interactive markers to your map with advanced features.
+
+**Topics Covered**:
+- Marker creation and positioning
+- Draggable markers with event handling
+- Marker popups with custom content
+- Marker clustering
+- Marker icons and styling
+- Marker removal and updates
+
+**Key Composables**:
+- `useCreateMarker()` - Programmatic marker creation
+- `useCreatePopup()` - Marker popups
+- `useMapEventListener()` - Interaction events
+
+**Key Components**:
+- `<Marker />` - Marker component
+- `<PopUp />` - Popup overlays
 
 ### 🎨 [Layers](/examples/layers)
 
-Work with different layer types including fill, circle, line, and symbol layers with dynamic styling.
+Work with all layer types: Fill, Circle, Line, and Symbol layers.
+
+**Topics Covered**:
+- Fill layers for polygons with styling
+- Circle layers for points with size/color
+- Line layers for routes/boundaries
+- Symbol layers for text/icons
+- Layer painting and layout properties
+- Reactive style updates
+- Layer filtering by properties
+- Layer z-order management
+
+**Key Composables** (all with full type safety):
+- `useCreateFillLayer()` - Fill layers
+- `useCreateCircleLayer()` - Circle layers
+- `useCreateLineLayer()` - Line layers
+- `useCreateSymbolLayer()` - Symbol layers
+
+**Key Components**:
+- `<FillLayer />` - Fill layer component
+- `<CircleLayer />` - Circle layer component
+- `<LineLayer />` - Line layer component
+- `<SymbolLayer />` - Symbol layer component
 
 ### 🎮 [Controls](/examples/controls)
 
-Add navigation controls, geolocation, and custom controls to enhance user interaction.
+Integrate navigation controls and geolocation features.
+
+**Topics Covered**:
+- Geolocation control initialization
+- User location tracking
+- Geolocation events and permissions
+- Custom control positioning
+- Control state management
+- Error handling for location services
+
+**Key Composables**:
+- `useGeolocateControl()` - Programmatic geolocation
+- `useGeolocateEventListener()` - Geolocate events
+
+**Key Components**:
+- `<GeolocateControls />` - Geolocation control
 
 ## Example Structure
 
 Each example includes:
 
-- **Live Demo**: Interactive code that you can copy and use
-- **Source Code**: Complete Vue component with explanations
-- **Key Features**: Highlighted functionality and use cases
-- **Related APIs**: Links to relevant components and composables
+| Section | Content |
+|---------|----------|
+| **Live Demo** | Interactive map with full functionality |
+| **Code** | Complete Vue component with explanations |
+| **Features** | Key capabilities highlighted |
+| **APIs** | Links to relevant composables/components |
+| **Variations** | Alternative approaches and patterns |
+
+## Common Patterns
+
+### Data Updates
+
+```typescript
+const geoData = ref({ type: 'FeatureCollection', features: [] });
+
+// Update data reactively
+watch(() => selectedRegion.value, (region) => {
+  const filtered = allFeatures.filter(f => f.properties.region === region);
+  geoData.value = { type: 'FeatureCollection', features: filtered };
+});
+```
+
+### Camera Animations
+
+```typescript
+const { flyTo } = useFlyTo(mapInstance);
+
+const animateToLocation = async (location) => {
+  try {
+    await flyTo({ center: location, zoom: 10 });
+  } catch (error) {
+    console.error('Animation failed:', error);
+  }
+};
+```
+
+### Event Handling
+
+```typescript
+const { isListenerAttached } = useMapEventListener('click', (e) => {
+  console.log('Clicked at:', e.lngLat);
+  // Get features at click point
+  const features = mapInstance.value?.queryRenderedFeatures({ layers: ['my-layer'] });
+});
+```
+
+### Layer Styling
+
+```typescript
+const { setPaint, setFilter } = useCreateCircleLayer(mapInstance, sourceId);
+
+// Type-safe property updates
+watch(() => settings.radius, (newRadius) => {
+  setPaint({ 'circle-radius': newRadius, 'circle-color': '#088' });
+});
+
+watch(() => filters.name, (name) => {
+  setFilter(['in', 'name', ...name.split(',')]);
+});
+```
 
 ## Running Examples Locally
 
-You can run these examples in your local development environment:
+### Using the Example App
 
-1. Clone the repository
+Clone the repository and run the example app:
+
+```bash
+git clone https://github.com/danh121097/vue-maplibre-gl
+cd vue-maplibre-gl/examples
+bun install
+bun dev
+```
+
+Then open http://localhost:5173 in your browser.
+
+### Copy & Paste
+
+You can copy any example code and paste it into your Vue 3 project. All examples are standalone and include necessary imports.
+
+## Best Practices
+
+1. **Always handle map readiness** before operations
+   ```typescript
+   watch(isMapReady, () => {
+     // Map is interactive now
+   });
+   ```
+
+2. **Use type-safe layer composables** for compile-time validation
+   ```typescript
+   const { setPaint } = useCreateFillLayer(map, source);
+   // setPaint only accepts FillPaint types
+   ```
+
+3. **Await camera animations** for sequential operations
+   ```typescript
+   await flyTo({ center: [0, 0], zoom: 10 });
+   // Camera animation complete
+   ```
+
+4. **Clean up listeners** (automatic with composables)
+   ```typescript
+   const { removeListener } = useMapEventListener('click', handler);
+   // Removed on component unmount automatically
+   ```
+
+5. **Use reactive data** for real-time updates
+   ```typescript
+   const geoData = ref({...});
+   watch(() => externalData, () => {
+     geoData.value = transformedData;
+   });
+   ```
+
+## Advanced Topics
+
+### Performance Optimization
+
+- Use `GeoJsonSource` with clustering for large datasets
+- Filter data on the backend before sending
+- Use `watch` with debounce for frequent updates
+- Optimize GeoJSON complexity (simplify geometries)
+
+### State Management
+
+- Use `register` callback for Pinia/Vuex integration
+- Store map state in application state management
+- Sync URL params with map camera position
+
+### Custom Controls
+
+- Build on top of `useMaplibre()` composable
+- Listen to map events with `useMapEventListener()`
+- Update UI based on map state reactively
+
+## Troubleshooting
+
+### Map Not Showing
+
+- **Check**: Container has height (e.g., `style="height: 500px"`)
+- **Check**: CSS is imported (`import 'vue3-maplibre-gl/dist/style.css'`)
+- **Check**: MapOptions includes valid `style` URL
+
+### Events Not Firing
+
+- **Check**: Listener attached before map ready
+- **Check**: Event name is correct (see MapLibre GL docs)
+- **Check**: Map instance is valid and ready
+
+### Data Not Updating
+
+- **Check**: Using `ref()` for reactive data
+- **Check**: Updating `geoData.value` not reassigning
+- **Check**: Source ID matches layer sourceId
+
+## More Resources
+
+- [Component API Reference](/api/components)
+- [Composables API Reference](/api/composables)
+- [Type Reference](/api/types)
+- [Getting Started Guide](/guide/getting-started)
+- [SSR/Nuxt Guide](/guide/ssr-nuxt)
+- [GitHub Repository](https://github.com/danh121097/vue-maplibre-gl)
+
 2. Install dependencies: `yarn install`
 3. Start the development server: `yarn dev`
 4. Navigate to the examples section

--- a/docs/guide/composables-overview.md
+++ b/docs/guide/composables-overview.md
@@ -1,65 +1,489 @@
 # Composables Overview
 
-Quick reference for all 15+ composables available in vue3-maplibre-gl.
+Comprehensive reference for all 20+ composables available in vue3-maplibre-gl v5.
 
-## Map Management
+## Architecture (v5)
 
-| Composable | Description |
-|---|---|
-| `useCreateMaplibre` | Create map instance with error handling and SSR guard |
-| `useMaplibre` | Simplified map state management with all map methods |
+All composables in v5 follow the **factory pattern** for code reuse and maintainability:
 
-## Layer Management
+- **Event Listeners** (3 composables) → 1 factory (`createEventListenerComposable`)
+- **Camera Animations** (7+ composables) → 1 factory (`createCameraAnimation`)
+- **Layer Property Setters** (4 composables) → 1 factory (`createPropertySetter`)
 
-| Composable | Description |
-|---|---|
-| `useCreateFillLayer` | Fill polygons with customizable paint/layout |
-| `useCreateCircleLayer` | Point data as circles with typed property setters |
-| `useCreateLineLayer` | Linear features (routes, boundaries) |
-| `useCreateSymbolLayer` | Icons and text labels with 30+ property setters |
-| `useCreateLayer` | Base layer composable (used internally by type-specific ones) |
+**Result**: 59% code reduction with identical API surface.
 
-## Source Management
+## Map Management (3)
 
-| Composable | Description |
-|---|---|
-| `useCreateGeoJsonSource` | GeoJSON data source with reactive data updates |
-| `useGeoJsonSource` | Simplified source management |
+### `useCreateMaplibre(elRef, styleRef, props)`
 
-## Events
+Create and manage a MapLibre GL instance with full lifecycle support.
 
-| Composable | Description |
-|---|---|
-| `useMapEventListener` | Map-level events (click, move, zoom, etc.) |
-| `useLayerEventListener` | Layer-specific events with 3-arg `.on()` |
-| `useGeolocateEventListener` | Geolocate control events |
+**Parameters**:
 
-## Camera Animations
+- `elRef: MaybeRef<HTMLElement | undefined | null>` - Container element
+- `styleRef: MaybeRef<StyleSpecification | string>` - Map style URL or object
+- `props?: CreateMaplibreProps` - Configuration (center, zoom, bearing, etc.)
 
-| Composable | Returns | Completion |
-|---|---|---|
-| `useFlyTo` | `flyTo`, `flyToCenter`, `flyToZoom`, `stopFlying` | Promise (moveend) |
-| `useEaseTo` | `easeTo`, `easeToCenter`, `stopEasing` | Promise (moveend) |
-| `useJumpTo` | `jumpTo`, `jumpToCenter`, `jumpToZoom` | Instant |
-| `useFitBounds` | `setFitBounds`, `clearBounds` | Sync |
-| `useZoomTo/In/Out` | `zoomTo`, `zoomIn`, `zoomOut`, `stopZooming` | Promise (zoomend) |
-| `usePanBy/To` | `panBy`, `panTo`, `stopPanning` | Promise (moveend) |
-| `useRotateTo` | `rotateTo`, `stopRotating` | Promise (rotateend) |
-| `useResetNorth` | `resetNorth`, `stopRotating` | Promise (moveend) |
+**Returns**:
 
-## Controls
+```typescript
+{
+  mapInstance: ComputedRef<Map | null>,
+  mapCreationStatus: MapCreationStatus,
+  isMapReady: boolean,
+  isMapLoading: boolean,
+  hasMapError: boolean,
+  // Camera setters (reactive)
+  setStyle, setCenter, setZoom, setBearing, setPitch,
+  setMinZoom, setMaxZoom, setMinPitch, setMaxPitch,
+  setMaxBounds, setRenderWorldCopies,
+  // Callbacks
+  register?, onLoad?, onError?
+}
+```
 
-| Composable | Description |
-|---|---|
+**Features**:
+
+- SSR-safe with `isBrowser` guard
+- Automatic cleanup on unmount
+- Map creation status tracking
+- Error handling and logging
+- Optional debug logging
+
+**Example**:
+
+```typescript
+const mapContainer = ref<HTMLElement>();
+const { mapInstance, isMapReady, setCenter, setZoom } = useCreateMaplibre(
+  mapContainer,
+  'https://demotiles.maplibre.org/style.json',
+  { center: [0, 0], zoom: 6 },
+);
+
+watch(isMapReady, () => {
+  // Map is interactive, safe to use
+  setCenter([100, 50]);
+});
+```
+
+### `useMaplibre()`
+
+Access the map context in child components without prop drilling.
+
+**Returns**: Same as `useCreateMaplibre` (from injected context)
+
+**Throws**: Error if not within `<Maplibre>` component
+
+**Example**:
+
+```typescript
+// In any child component under Maplibre
+const { mapInstance, isMapReady, setZoom } = useMaplibre();
+
+const zoomToFit = () => {
+  if (isMapReady.value) setZoom(10);
+};
+```
+
+### `useMaplibreConfig(mapInstance, options)`
+
+Reactively update map configuration options.
+
+**Parameters**:
+
+- `mapInstance: MaybeRef<Map | null>`
+- `options: Partial<MapOptions>` - Options to update
+
+**Returns**: `void` (configuration applied immediately)
+
+**Example**:
+
+```typescript
+const maxZoom = ref(15);
+watch(maxZoom, (newMax) => {
+  useMaplibreConfig(mapInstance, { maxZoom: newMax });
+});
+```
+
+## Layer Management (4)
+
+All layer composables use the **factory pattern** for type-safe property setters.
+
+### `useCreateFillLayer(mapInstance, sourceId, layerId?, style?)`
+
+Create and manage fill (polygon) layers with typed paint/layout properties.
+
+**Type Safety**: `setPaint` only accepts `FillPaint` types (compile-time validation)
+
+**Returns**:
+
+```typescript
+{
+  layerInstance: ShallowRef<Layer | null>,
+  setPaint: (paint: FillPaint) => void,
+  setLayout: (layout: FillLayout) => void,
+  setFilter: (filter: FilterSpecification) => void,
+  setOpacity: (opacity: number) => void,
+  remove: () => void
+}
+```
+
+**Example**:
+
+```typescript
+const { setPaint, setFilter } = useCreateFillLayer(
+  mapInstance,
+  'cities-source',
+  'cities-layer',
+);
+
+// Reactive property updates (type-safe)
+watch(
+  () => selectedColor.value,
+  (color) => {
+    setPaint({ 'fill-color': color, 'fill-opacity': 0.8 });
+  },
+);
+
+watch(
+  () => selectedRegion.value,
+  (region) => {
+    setFilter(['==', 'region', region]);
+  },
+);
+```
+
+### `useCreateCircleLayer(mapInstance, sourceId, layerId?, style?)`
+
+Create circle (point) layers with type-safe `CirclePaint` properties.
+
+**Returns**: Same pattern as `useCreateFillLayer` (CirclePaint types)
+
+### `useCreateLineLayer(mapInstance, sourceId, layerId?, style?)`
+
+Create line layers with type-safe `LinePaint` properties.
+
+**Returns**: Same pattern as `useCreateFillLayer` (LinePaint types)
+
+### `useCreateSymbolLayer(mapInstance, sourceId, layerId?, style?)`
+
+Create symbol (text/icon) layers with type-safe `SymbolPaint` properties.
+
+**Returns**: Same pattern as `useCreateFillLayer` (SymbolPaint types)
+
+### `useLayer<T extends LayerSpecification>(mapInstance, sourceId, config)`
+
+Generic layer composable for advanced use cases.
+
+**Type Parameter**: `T` - Layer specification type (enables generic type preservation)
+
+**Example**:
+
+```typescript
+const { setPaint } = useLayer<CircleLayerSpecification>(
+  mapInstance,
+  'source-id',
+  { type: 'circle', id: 'layer-id' },
+);
+```
+
+## Source Management (2)
+
+### `useCreateGeoJsonSource(map, sourceId, data, options?)`
+
+Create and manage GeoJSON data sources with reactive updates.
+
+**Returns**:
+
+```typescript
+{
+  sourceInstance: ShallowRef<GeoJSONSource | null>,
+  setData: (data: GeoJSON.Feature[] | GeoJSON.FeatureCollection) => void,
+  updateFeature: (featureId: any, properties: any) => void,
+  getFeatures: () => Feature[] | undefined,
+  queryFeatures: (bbox?: LngLatBoundsLike) => Feature[] | undefined
+}
+```
+
+**Example**:
+
+```typescript
+const { setData } = useCreateGeoJsonSource(
+  mapInstance,
+  'cities-source',
+  citiesGeoJSON,
+);
+
+// Update data reactively
+watch(
+  () => filters.region,
+  (region) => {
+    const filtered = allCities.filter((c) => c.properties.region === region);
+    setData({ type: 'FeatureCollection', features: filtered });
+  },
+);
+```
+
+### `useGeoJsonSource()`
+
+Access GeoJSON source from context (for child components).
+
+**Returns**: Source instance and methods (same as `useCreateGeoJsonSource`)
+
+## Event Listeners (3)
+
+All event listeners use the **factory pattern** with adapter pattern for different targets.
+
+### `useMapEventListener(event, handler, options?)`
+
+Listen to map-level events with automatic attach/detach.
+
+**Event Types**: All MapLibre map events
+
+- Mouse: `click`, `dblclick`, `mousemove`, `mouseup`, `mousedown`, `mouseout`, `mouseover`, `contextmenu`
+- Movement: `movestart`, `move`, `moveend`, `zoomstart`, `zoom`, `zoomend`, `dragstart`, `drag`, `dragend`
+- Rotation: `rotatestart`, `rotate`, `rotateend`, `pitchstart`, `pitch`, `pitchend`
+- Data: `data`, `tiledataloading`, `sourcedata`, `styledata`
+- Other: `wheel`, `load`, `error`, `idle`, `render`, `remove`, `terrain`
+
+**Handler Type**: `(e: MapMouseEvent) => void` (or appropriate event type)
+
+**Returns**:
+
+```typescript
+{
+  removeListener: () => void,
+  attachListener: () => void,
+  isListenerAttached: boolean,
+  listenerStatus: EventListenerStatus
+}
+```
+
+**Example**:
+
+```typescript
+const handleMapClick = (e: MapMouseEvent) => {
+  console.log('Clicked at', e.lngLat);
+};
+
+const { isListenerAttached } = useMapEventListener('click', handleMapClick, {
+  map: mapInstance,
+});
+
+// Listener automatically attached and cleaned up
+```
+
+### `useLayerEventListener<T extends keyof MapLayerEventType>(event, handler, options?)`
+
+Listen to layer-specific events with feature information.
+
+**Handler Type**: `(e: MapMouseEvent & { features?: GeoJSON.Feature[] }) => void`
+
+**Returns**: Same as `useMapEventListener`
+
+**Example**:
+
+```typescript
+const handleLayerClick = (e: MapMouseEvent & { features?: Feature[] }) => {
+  e.features?.forEach((feature) => {
+    console.log('Clicked feature:', feature.properties);
+  });
+};
+
+const { isListenerAttached } = useLayerEventListener(
+  'click',
+  handleLayerClick,
+  {
+    map: mapInstance,
+    layerId: 'my-layer',
+  },
+);
+```
+
+### `useGeolocateEventListener(event, handler, options?)`
+
+Listen to geolocation control events.
+
+**Event Types**: `geolocate`, `error`, `outofmaxbounds`, `trackuserlocationstart`, `trackuserlocationend`
+
+**Handler Type**: `(e: GeolocateSuccess | GeolocationPositionError) => void`
+
+**Returns**: Same as `useMapEventListener`
+
+## Camera Animations (7+)
+
+All camera animations use the **factory pattern** with promise-wrapping for `async/await` support.
+
+### `useFlyTo(map, options?)`
+
+Smooth flight animation to a new location.
+
+**Returns**:
+
+```typescript
+{
+  flyTo: (target: Partial<CameraOptions>) => Promise<void>,
+  isAnimating: boolean,
+  animationStatus: AnimationStatus
+}
+```
+
+**Completes on**: `moveend` event or timeout (optional)
+
+**Example**:
+
+```typescript
+const { flyTo, isAnimating } = useFlyTo(mapInstance);
+
+const handleFlyTo = async () => {
+  try {
+    await flyTo({ center: [100, 50], zoom: 10 });
+    console.log('Animation complete');
+  } catch (error) {
+    console.error('Animation failed:', error);
+  }
+};
+```
+
+### `useEaseTo(map, options?)`
+
+Smooth easing animation (similar to flyTo but different curve).
+
+**Returns**: Same as `useFlyTo`
+
+**Completes on**: `moveend` event or timeout
+
+### `useJumpTo(map, options?)`
+
+Instant camera jump (no animation).
+
+**Returns**: Same as `useFlyTo`
+
+**Completes on**: Immediately (synchronous)
+
+### `useFitBounds(map, options?)`
+
+Zoom/pan to fit bounds with animation.
+
+**Returns**: Same as `useFlyTo`
+
+**Example**:
+
+```typescript
+const { fitBounds } = useFitBounds(mapInstance);
+await fitBounds(
+  [
+    [-74, 40],
+    [-73, 41],
+  ],
+  { padding: 50 },
+);
+```
+
+### `useCameraForBounds(map, options?)`
+
+Calculate optimal camera position for bounds (without animating).
+
+**Returns**: Synchronous camera options
+
+### `useZoomTo(map, options?)`
+
+Animate to specific zoom level.
+
+**Returns**: `{ zoomTo: (zoom: number) => Promise<void>, ... }`
+
+### `useZoomIn / useZoomOut(map, options?)`
+
+Step zoom up/down (+/- 1 level).
+
+**Returns**: `{ zoomIn / zoomOut: () => Promise<void>, ... }`
+
+### `usePanBy / usePanTo(map, options?)`
+
+Pan map by offset or to location.
+
+**Returns**: `{ panBy / panTo: (offset/lnglat) => Promise<void>, ... }`
+
+### `useRotateTo(map, options?)`
+
+Rotate map to bearing.
+
+**Returns**: `{ rotateTo: (bearing: number) => Promise<void>, ... }`
+
+### `useResetNorth(map, options?)`
+
+Reset bearing to north (0°).
+
+**Returns**: `{ resetNorth: () => Promise<void>, ... }`
+
+### `useResetNorthPitch(map, options?)`
+
+Reset bearing to north and pitch to 0°.
+
+**Returns**: `{ resetNorthPitch: () => Promise<void>, ... }`
+
+### `useSnapToNorth(map, options?)`
+
+Snap to nearest north angle (0°, 90°, 180°, 270°).
+
+**Returns**: `{ snapToNorth: () => Promise<void>, ... }`
+
+## Controls (1)
+
+### `useGeolocateControl(mapInstance, options?)`
+
+Programmatic access to geolocation control.
+
+**Returns**:
+
+```typescript
+{
+  geolocateInstance: ShallowRef<GeolocateControl | null>,
+  trigger: () => void,
+  startTracking: () => void,
+  stopTracking: () => void
+}
+```
+
+## Utility Composables
+
+### `useCreateMarker(map, lnglat, options?)`
+
+Create markers programmatically.
+
+**Returns**: `{ markerInstance: ShallowRef<Marker | null>, setLngLat, remove }`
+
+### `useCreatePopup(map, options?)`
+
+Create popups programmatically.
+
+**Returns**: `{ popupInstance: ShallowRef<Popup | null>, setLngLat, show, hide }`
+
+### `useCreateImage(map, id, url, coordinates?)`
+
+Add images to map for image layers.
+
+**Returns**: `{ imageInstance: ShallowRef<HTMLImageElement | null>, updateUrl, updateCoordinates }`
+
+## Best Practices
+
+1. **Always check map ready state** before operations
+2. **Use watch/watchEffect** for reactive updates
+3. **Handle promises** from animations with try/catch
+4. **Clean up listeners** (automatic via composables)
+5. **Use type-safe layer composables** for compile-time validation
+
+| Composable            | Description                        |
+| --------------------- | ---------------------------------- |
 | `useGeolocateControl` | User location tracking with events |
 
 ## Utilities
 
-| Composable | Description |
-|---|---|
-| `useLogger` | Consistent debug logging (controlled via `debug` prop) |
-| `useDebounce` | Debounced function execution |
-| `useOptimizedComputed` | Cached computed with shallow equality |
+| Composable             | Description                                            |
+| ---------------------- | ------------------------------------------------------ |
+| `useLogger`            | Consistent debug logging (controlled via `debug` prop) |
+| `useDebounce`          | Debounced function execution                           |
+| `useOptimizedComputed` | Cached computed with shallow equality                  |
 
 ## Factory Functions (Advanced)
 
@@ -67,10 +491,10 @@ These are used internally but exported for custom extensions:
 
 ```typescript
 import {
-  createEventListenerComposable,  // Build custom event listeners
-  createCameraAnimation,          // Build custom camera animations
-  createPropertySetter,           // Build typed layer property setters
-  createSetStyle,                 // Build setStyle for custom layers
-  LAYER_STYLE_CONFIG,             // Paint/layout key definitions
+  createEventListenerComposable, // Build custom event listeners
+  createCameraAnimation, // Build custom camera animations
+  createPropertySetter, // Build typed layer property setters
+  createSetStyle, // Build setStyle for custom layers
+  LAYER_STYLE_CONFIG, // Paint/layout key definitions
 } from 'vue3-maplibre-gl';
 ```

--- a/docs/guide/ssr-nuxt.md
+++ b/docs/guide/ssr-nuxt.md
@@ -1,30 +1,226 @@
 # SSR / Nuxt
 
-vue3-maplibre-gl v5 is SSR-safe out of the box. Map creation is guarded with `isBrowser` checks and all `window.*` references have been removed.
+vue3-maplibre-gl v5 is **SSR-safe out of the box**. Map creation is guarded with `isBrowser` checks and all `window.*` references have been removed.
 
-## Nuxt Module (Recommended)
+## Why SSR Compatibility Matters
 
-Install the official Nuxt module for the best DX — auto-imports components, composables, and CSS:
+MapLibre GL requires:
+
+- WebGL context (browser exclusive)
+- DOM manipulation (render phase only)
+- window/document APIs
+
+Without SSR guards, rendering on the server would fail. Vue3 MapLibre GL v5 handles this automatically.
+
+## Nuxt Module (Recommended) - v1.0.0
+
+The official Nuxt module handles SSR configuration automatically. Install it for the best DX:
 
 ```bash
 bun add nuxt-maplibre-gl
+# or
+npm install nuxt-maplibre-gl
 ```
+
+### Setup
 
 ```typescript
 // nuxt.config.ts
 export default defineNuxtConfig({
   modules: ['nuxt-maplibre-gl'],
+
   maplibre: {
-    css: true,    // auto-import CSS (default)
-    prefix: '',   // composable prefix (default: none)
+    /**
+     * Auto-import vue3-maplibre-gl CSS styles
+     * @default true
+     */
+    css: true,
+
+    /**
+     * Prefix for auto-imported composables
+     * Set to 'map' to use mapUseMaplibre, mapUseFlyTo, etc.
+     * @default '' (no prefix)
+     */
+    prefix: '',
   },
 });
 ```
 
-With the module installed, all components and composables are auto-imported. Just wrap in `<ClientOnly>`:
+### Module Features
+
+The module automatically configures:
+
+1. **CSS Auto-Import** - `vue3-maplibre-gl/dist/style.css` injected
+2. **Component Auto-Import** - All 10 components available without imports
+3. **Composable Auto-Import** - All 15+ composables available without imports
+4. **SSR Support** - Map components rendered only on client
+5. **Build Configuration**:
+   - vue3-maplibre-gl transpiled for SSR
+   - maplibre-gl excluded from SSR bundle (requires WebGL)
+   - vite.optimizeDeps.exclude configured
+
+### Usage
+
+With the module installed, use components and composables directly in templates/scripts without imports:
 
 ```vue
 <template>
+  <ClientOnly>
+    <!-- Components available without imports -->
+    <Maplibre :options="mapOptions" style="height: 500px">
+      <GeoJsonSource :data="geoData">
+        <FillLayer :style="fillStyle" />
+      </GeoJsonSource>
+    </Maplibre>
+  </ClientOnly>
+</template>
+
+<script setup>
+// No imports needed - all auto-imported by module
+import { ref } from 'vue';
+
+const mapOptions = ref({
+  style: 'https://demotiles.maplibre.org/style.json',
+  center: [0, 0],
+  zoom: 2,
+});
+
+const geoData = ref({
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [0, 0] },
+      properties: { name: 'Center' },
+    },
+  ],
+});
+
+const fillStyle = ref({
+  'fill-color': '#088',
+  'fill-opacity': 0.8,
+});
+
+// Composables auto-imported
+const { mapInstance, isMapReady } = useMaplibre();
+
+watch(isMapReady, async () => {
+  // Map is ready
+  const { flyTo } = useFlyTo(mapInstance);
+  await flyTo({ center: [100, 50], zoom: 10 });
+});
+</script>
+```
+
+### Auto-Imported Composables
+
+The Nuxt module auto-imports these composables by default:
+
+```typescript
+// Map Management
+(useCreateMaplibre, useMaplibre, useMaplibreConfig);
+
+// Camera Animations (7)
+(useFlyTo,
+  useEaseTo,
+  useJumpTo,
+  useFitBounds,
+  useCameraForBounds,
+  usePanBy,
+  usePanTo,
+  useZoomTo,
+  // Zoom/Rotation (6)
+  useZoomIn,
+  useZoomOut,
+  useRotateTo,
+  useResetNorth,
+  useResetNorthPitch,
+  useSnapToNorth);
+
+// Layers (4)
+(useCreateFillLayer,
+  useCreateCircleLayer,
+  useCreateLineLayer,
+  useCreateSymbolLayer);
+
+// Events (3)
+(useMapEventListener, useLayerEventListener, useGeolocateEventListener);
+
+// Sources (2)
+(useCreateGeoJsonSource, useGeoJsonSource);
+
+// Controls
+useGeolocateControl;
+```
+
+### Auto-Imported Components
+
+```typescript
+// Core
+(Maplibre, GeoJsonSource);
+
+// Layers (4)
+(FillLayer, CircleLayer, LineLayer, SymbolLayer);
+
+// Overlays
+(Marker, PopUp, Image);
+
+// Controls
+GeolocateControls;
+```
+
+### Using Composable Prefix
+
+Optionally add a prefix to avoid conflicts:
+
+```typescript
+// nuxt.config.ts
+maplibre: {
+  prefix: 'map',
+}
+```
+
+Then use with prefix:
+
+```typescript
+// Composables now prefixed
+mapUseMaplibre(); // instead of useMaplibre()
+mapUseFlyTo(); // instead of useFlyTo()
+mapUseMapEventListener(); // instead of useMapEventListener()
+```
+
+## Manual Setup (Without Module)
+
+If you prefer not to use the module, follow these steps:
+
+### 1. Install Package
+
+```bash
+bun add vue3-maplibre-gl
+```
+
+### 2. Configure Nuxt
+
+```typescript
+// nuxt.config.ts
+export default defineNuxtConfig({
+  css: ['vue3-maplibre-gl/dist/style.css'],
+  build: {
+    transpile: ['vue3-maplibre-gl'],
+  },
+  vite: {
+    optimizeDeps: {
+      exclude: ['maplibre-gl'],
+    },
+  },
+});
+```
+
+### 3. Wrap Components in ClientOnly
+
+```vue
+<template>
+  <!-- Critical: Wrap map components in ClientOnly -->
   <ClientOnly>
     <Maplibre :options="mapOptions" style="height: 500px">
       <GeoJsonSource :data="geoData">
@@ -35,19 +231,148 @@ With the module installed, all components and composables are auto-imported. Jus
 </template>
 
 <script setup>
-const mapOptions = ref({
-  style: 'https://demotiles.maplibre.org/style.json',
-  center: [0, 0],
-  zoom: 2,
-});
-const geoData = ref({ type: 'FeatureCollection', features: [] });
-const fillStyle = ref({ 'fill-color': '#088', 'fill-opacity': 0.8 });
+import { ref } from 'vue';
+import {
+  Maplibre,
+  GeoJsonSource,
+  FillLayer,
+  useMaplibre,
+  useFlyTo,
+} from 'vue3-maplibre-gl';
+import 'vue3-maplibre-gl/dist/style.css';
+
+// ... rest of component
 </script>
 ```
 
-## Manual Setup (Without Module)
+## SSR Internals
 
-If you prefer not to use the module, wrap map components in `<ClientOnly>` since MapLibre GL requires WebGL (browser-only):
+Understanding what happens under the hood:
+
+### Browser Guards
+
+All components check `isBrowser` before creating map instances:
+
+```typescript
+import { isBrowser } from 'vue3-maplibre-gl';
+
+if (isBrowser) {
+  // Safe to create MapLibre instance
+  const map = new Map({ container: el, style: 'url' });
+}
+// On server: skipped, no error
+```
+
+### maplibre-gl Exclusion
+
+The maplibre-gl package is excluded from SSR bundling:
+
+```typescript
+// Usually removed from server bundle
+import { Map, GeoJSONSource } from 'maplibre-gl';
+// Server: import fails gracefully (never called)
+// Client: import succeeds (WebGL available)
+```
+
+### ClientOnly Wrapper
+
+Ensures components only render in the browser:
+
+```vue
+<ClientOnly>
+  <!-- Rendered only on client -->
+  <Maplibre ... />
+</ClientOnly>
+<!-- Fallback shown during hydration -->
+```
+
+## Deployment Considerations
+
+### Nuxt SSR Deployment (Vercel, Netlify, etc.)
+
+1. **Module handles everything** - Deploy as normal
+2. **Check build logs** - Verify maplibre-gl excluded from server build
+3. **Test locally first** - `nuxi generate` for static generation
+
+### Hybrid Rendering (Nuxt)
+
+Use route rules for optimal performance:
+
+```typescript
+// nuxt.config.ts
+export default defineNuxtConfig({
+  routeRules: {
+    '/maps/**': { swr: 3600 }, // ISR: revalidate hourly
+  },
+});
+```
+
+### Static Generation (SSG)
+
+Maps can't be pre-rendered (client-only), use hybrid rendering:
+
+```typescript
+// nuxt.config.ts
+export default defineNuxtConfig({
+  nitro: {
+    prerender: {
+      crawlLinks: true,
+      // Exclude map routes from prerendering
+      ignore: ['/maps'],
+    },
+  },
+});
+```
+
+## Troubleshooting
+
+### "window is not defined"
+
+**Cause**: Map component rendered on server
+
+**Fix**: Wrap in `<ClientOnly>`
+
+```vue
+<ClientOnly>
+  <Maplibre ... />
+</ClientOnly>
+```
+
+### "WebGL context lost"
+
+**Cause**: Usually transient, map recovers automatically
+
+**Fix**: Use `onError` callback to recover
+
+```vue
+<Maplibre :options="options" @error="handleMapError" />
+```
+
+### "maplibre-gl not found"
+
+**Cause**: Not transpiled for SSR
+
+**Fix**: Configure Nuxt
+
+```typescript
+build: {
+  transpile: ['vue3-maplibre-gl'],
+}
+```
+
+## Performance Tips
+
+1. **Lazy load maps** - Use dynamic imports for map pages
+2. **Use route preloading** - Prefetch map routes
+3. **Optimize GeoJSON** - Simplify geometries before sending
+4. **Enable data compression** - gzip GeoJSON responses
+5. **Cache styles** - Browser cache map styles (long TTL)
+
+## Further Reading
+
+- [Nuxt SSR Documentation](https://nuxt.com/docs/guide/concepts/rendering)
+- [MapLibre GL Documentation](https://maplibre.org/maplibre-gl-js/docs/)
+- [Nuxt Module Authoring](https://nuxt.com/docs/guide/going-further/modules)
 
 ```vue
 <template>
@@ -106,6 +431,7 @@ export const isBrowser =
 ```
 
 This guard is checked before:
+
 - Map creation (`useCreateMaplibre`)
 - Marker creation (`useCreateMarker`)
 - Popup creation (`useCreatePopup`)

--- a/libs/composables/utils/__tests__/create-camera-animation.test.ts
+++ b/libs/composables/utils/__tests__/create-camera-animation.test.ts
@@ -73,9 +73,9 @@ describe('createCameraAnimation', () => {
       createCameraAnimation({ map: ref(null) }),
     );
 
-    await expect(
-      executeAnimation('flyTo', [{}], 'moveend'),
-    ).rejects.toThrow('Map instance not available');
+    await expect(executeAnimation('flyTo', [{}], 'moveend')).rejects.toThrow(
+      'Map instance not available',
+    );
   });
 
   it('rejects on timeout and calls map.stop() (RT-6)', async () => {

--- a/nuxt/package.json
+++ b/nuxt/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "author": {
     "name": "Danh Nguyen",
-    "url": "https://github.com/danh121097"
+    "url": "https://harrynguyen.work"
   },
   "homepage": "https://github.com/danh121097/vue-maplibre-gl#readme",
   "bugs": {

--- a/nuxt/package.json
+++ b/nuxt/package.json
@@ -4,6 +4,14 @@
   "description": "Nuxt module for vue3-maplibre-gl — auto-import components, composables, CSS, and SSR configuration",
   "type": "module",
   "license": "MIT",
+  "author": {
+    "name": "Danh Nguyen",
+    "url": "https://github.com/danh121097"
+  },
+  "homepage": "https://github.com/danh121097/vue-maplibre-gl#readme",
+  "bugs": {
+    "url": "https://github.com/danh121097/vue-maplibre-gl/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/danh121097/vue-maplibre-gl",
@@ -30,7 +38,8 @@
   "main": "./dist/module.mjs",
   "types": "./dist/types.d.mts",
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "dev:prepare": "nuxt-module-build build --stub && nuxi prepare playground",

--- a/nuxt/src/module.ts
+++ b/nuxt/src/module.ts
@@ -16,7 +16,8 @@ export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: 'nuxt-maplibre-gl',
     configKey: 'maplibre',
-    description: 'Nuxt module for vue3-maplibre-gl with auto-import, SSR support, and full TypeScript',
+    description:
+      'Nuxt module for vue3-maplibre-gl with auto-import, SSR support, and full TypeScript',
     links: {
       documentation: 'https://github.com/danh121097/vue-maplibre-gl',
       repository: 'https://github.com/danh121097/vue-maplibre-gl',
@@ -55,15 +56,31 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Auto-import composables
     const composables = [
-      'useCreateMaplibre', 'useMaplibre',
-      'useCreateFillLayer', 'useCreateCircleLayer', 'useCreateLineLayer', 'useCreateSymbolLayer',
-      'useCreateGeoJsonSource', 'useGeoJsonSource',
-      'useMapEventListener', 'useLayerEventListener', 'useGeolocateEventListener',
-      'useFlyTo', 'useEaseTo', 'useJumpTo',
-      'useFitBounds', 'useCameraForBounds',
-      'useZoomTo', 'useZoomIn', 'useZoomOut',
-      'usePanBy', 'usePanTo',
-      'useRotateTo', 'useResetNorth', 'useResetNorthPitch', 'useSnapToNorth',
+      'useCreateMaplibre',
+      'useMaplibre',
+      'useCreateFillLayer',
+      'useCreateCircleLayer',
+      'useCreateLineLayer',
+      'useCreateSymbolLayer',
+      'useCreateGeoJsonSource',
+      'useGeoJsonSource',
+      'useMapEventListener',
+      'useLayerEventListener',
+      'useGeolocateEventListener',
+      'useFlyTo',
+      'useEaseTo',
+      'useJumpTo',
+      'useFitBounds',
+      'useCameraForBounds',
+      'useZoomTo',
+      'useZoomIn',
+      'useZoomOut',
+      'usePanBy',
+      'usePanTo',
+      'useRotateTo',
+      'useResetNorth',
+      'useResetNorthPitch',
+      'useSnapToNorth',
     ];
 
     addImports(

--- a/nuxt/src/module.ts
+++ b/nuxt/src/module.ts
@@ -16,6 +16,11 @@ export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: 'nuxt-maplibre-gl',
     configKey: 'maplibre',
+    description: 'Nuxt module for vue3-maplibre-gl with auto-import, SSR support, and full TypeScript',
+    links: {
+      documentation: 'https://github.com/danh121097/vue-maplibre-gl',
+      repository: 'https://github.com/danh121097/vue-maplibre-gl',
+    },
     compatibility: {
       nuxt: '>=3.0.0',
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "description": "Vue 3 components and composables for MapLibre GL JS - Build interactive maps with ease",
   "version": "5.0.0",
   "author": {
-    "name": "Danh Nguyen"
+    "name": "Danh Nguyen",
+    "url": "https://harrynguyen.work"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add v5.0.0 refactor and stabilization changes
- add Nuxt module package nuxt-maplibre-gl v1.0.0 metadata and docs
- fix CI lint and type issues in tests and Nuxt playground
- add portfolio author URL in both package manifests
- chain CI/CD workflows in this order: CI -> docs deploy -> auto release -> npm publish

## Validation
- bun run type-check
- bun run lint:check
- bun run test
- bun run build

## Required Secrets
- NPM_TOKEN
- VERCEL_TOKEN
- VERCEL_ORG_ID
- VERCEL_PROJECT_ID